### PR TITLE
Fixed heroku deployment issues with memcache and New Relic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'newrelic_rpm', '>=3.5'
 gem "pg", ">= 0.14.1"
 
 group :production do
+  gem 'memcachier'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    memcachier (0.0.2)
     mime-types (1.21)
     multi_json (1.6.1)
     multi_xml (0.5.3)
@@ -120,6 +121,7 @@ DEPENDENCIES
   dalli
   httparty
   jquery-rails
+  memcachier
   newrelic_rpm (>= 3.5)
   nokogiri
   pg (>= 0.14.1)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Step 2
 Deploy your app to Heroku and load the database there
 
     heroku apps:create
-    heroky addons:add pgbackups:plus newrelic:standard memcache:5mb
+    heroku addons:add pgbackups:plus
+    heroku addons:add newrelic:standard
+    heroku addons:add memcachier
     heroku pgbackups:restore DATABASE 'http://newrelic-ruby-kata.herokuapp.com/sample-data.dump'
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Deploy your app to Heroku and load the database there
     heroku addons:add newrelic:standard
     heroku addons:add memcachier
     heroku pgbackups:restore DATABASE 'http://newrelic-ruby-kata.herokuapp.com/sample-data.dump'
+    heroku config:set NEW_RELIC_APP_NAME="YOUR APP NAME GOES HERE"
     git push heroku master
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Deploy your app to Heroku and load the database there
     heroku addons:add newrelic:standard
     heroku addons:add memcachier
     heroku pgbackups:restore DATABASE 'http://newrelic-ruby-kata.herokuapp.com/sample-data.dump'
+    git push heroku master
 
 
 Step 3

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,9 +48,12 @@ git push heroku master</pre>
         <p>Populate the sample database and set up memcache.</p>
         <pre>heroku addons:add heroku-postgresql:dev
 heroku addons:add pgbackups:plus
-heroku addons:add memcache
+heroku addons:add memcachier
+heroku config:set NEW_RELIC_APP_NAME="YOUR APP NAME GOES HERE"
 	
 heroku pgbackups:restore DATABASE 'http://newrelic-ruby-kata.herokuapp.com/sample-data.dump'</pre>
+
+git push heroku master
     </div>
     <div class="span4">
       <h2>Step 5</h2>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,8 +40,7 @@ NewrelicRubyKata::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production
-  # config.cache_store = :mem_cache_store
-  # config.cache_store = :dalli_store
+  config.cache_store = :dalli_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"


### PR DESCRIPTION
There were a few issues with this part:

* Typo that said `heroky`
* It doesn't appear that you can add multiple addons at once like was in the markdown README
* The Heroku memcache addon was sunset in favor of memcachier
* The New Relic app name must be set to push data to New Relic (although this might have been part of the challenge?)