### PR TITLE
Use heroku-postgresql instead of pgbackups

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "logo": "http://storefront.nr-assets.net/assets/newrelic/source/NewRelic-logo-square.png",
   "success_url": "/",
   "addons": [
-    "pgbackups:plus",
+    "heroku-postgresql",
     "newrelic:stark",
     "memcachier"
   ],


### PR DESCRIPTION
Other PR's are updating the docs, but stepping through I got a warning on my
purple button deploy about that addons being missing, and then didn't have a
database when it started. This should fix it.

cc @tkrajcar 