### PR TITLE
Use newrelic:wayne instead of newrelic:stark

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   "success_url": "/",
   "addons": [
     "heroku-postgresql",
-    "newrelic:stark",
+    "newrelic:wayne",
     "memcachier"
   ],
   "keywords": [


### PR DESCRIPTION
Deploy fails with `stark` - no longer provided?